### PR TITLE
moveit plugin for planning grasp using moveit grasp

### DIFF
--- a/moveit.rosinstall
+++ b/moveit.rosinstall
@@ -19,7 +19,7 @@
 - git:
     local-name: rviz_visual_tools
     uri: https://github.com/PickNikRobotics/rviz_visual_tools
-    version: melodic-devel
+    version: master
 - git:
     local-name: geometric_shapes
     uri: https://github.com/ros-planning/geometric_shapes.git
@@ -31,4 +31,8 @@
 - git:
     local-name: moveit_tutorials
     uri: https://github.com/ros-planning/moveit_tutorials.git
+    version: melodic-devel
+- git:
+    local-name: moveit_grasps
+    uri: https://github.com/ros-planning/moveit_grasps.git
     version: melodic-devel

--- a/moveit_ros/grasps/CMakeLists.txt
+++ b/moveit_ros/grasps/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(catkin REQUIRED COMPONENTS
     moveit_ros_move_group
     moveit_ros_planning
     moveit_ros_planning_interface
+    crop_octomap
 )
 
 add_action_files(

--- a/moveit_ros/grasps/CMakeLists.txt
+++ b/moveit_ros/grasps/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(moveit_ros_grasp)
+
+add_compile_options(-std=c++11)
+
+find_package(Eigen3 REQUIRED)
+find_package(Boost REQUIRED thread system)
+find_package(OpenMP)
+
+find_package(catkin REQUIRED COMPONENTS
+    std_msgs
+    geometry_msgs
+    shape_msgs
+    actionlib_msgs
+    message_generation
+    actionlib
+    roscpp
+    moveit_grasps
+    tf
+    tf_conversions
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
+    trajectory_msgs
+    moveit_core
+    moveit_msgs
+    moveit_ros_move_group
+    moveit_ros_planning
+    moveit_ros_planning_interface
+)
+
+add_action_files(
+    DIRECTORY
+    action
+
+    FILES
+    GraspPlan.action
+)
+
+generate_messages(
+   DEPENDENCIES
+   actionlib_msgs
+   std_msgs
+   geometry_msgs
+   shape_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS 
+    actionlib_msgs
+    actionlib
+    roscpp
+  DEPENDS
+    EIGEN3
+)
+
+include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIR})
+link_directories(${catkin_LIBRARY_DIRS})
+
+set(MOVEIT_LIB_NAME moveit_move_group_grasp_capability)
+add_library(${MOVEIT_LIB_NAME}
+    src/grasp_action_capability.cpp
+)
+set_target_properties(${MOVEIT_LIB_NAME} PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+target_link_libraries(${MOVEIT_LIB_NAME} moveit_grasps moveit_grasps_filter ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+install(TARGETS ${MOVEIT_LIB_NAME}
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+
+install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+
+install(FILES grasp_capability_plugin_description.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/moveit_ros/grasps/action/GraspPlan.action
+++ b/moveit_ros/grasps/action/GraspPlan.action
@@ -1,0 +1,9 @@
+geometry_msgs/Pose object_pose
+shape_msgs/SolidPrimitive object_shape
+---
+bool success
+---
+geometry_msgs/Pose pregrasp_pose
+geometry_msgs/Pose approach_pose
+geometry_msgs/Pose lift_pose
+geometry_msgs/Pose retreat_pose

--- a/moveit_ros/grasps/grasp_capability_plugin_description.xml
+++ b/moveit_ros/grasps/grasp_capability_plugin_description.xml
@@ -1,0 +1,9 @@
+<library path="libmoveit_move_group_grasp_capability">
+
+  <class name="move_group/MoveGroupGraspAction" type="move_group::MoveGroupGraspAction" base_class_type="move_group::MoveGroupCapability">
+    <description>
+      Provide grasp capability using moveit_grasp to MoveGroup
+    </description>
+  </class>
+
+</library>

--- a/moveit_ros/grasps/include/moveit/move_group_grasp_capability/capability_names.h
+++ b/moveit_ros/grasps/include/moveit/move_group_grasp_capability/capability_names.h
@@ -1,0 +1,11 @@
+#ifndef MOVEIT_MOVE_GROUP_GRASP_CAPABILITY_NAMES
+#define MOVEIT_MOVE_GROUP_GRASP_CAPABILITY_NAMES
+
+#include <string>
+
+namespace move_group
+{
+static const std::string GRASP_ACTION = "grasp";
+}
+
+#endif

--- a/moveit_ros/grasps/package.xml
+++ b/moveit_ros/grasps/package.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>moveit_ros_grasp</name>
+  <version>0.0.0</version>
+  <description>The moveit_ros_grasp package</description>
+  <maintainer email="supratmanjoshua@gmail.com">Joshua Supratman</maintainer>
+
+  <license>Apache License, Version 2.0</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>actionlib</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>shape_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>moveit_core</build_depend>
+  <build_depend>moveit_ros_move_group</build_depend>
+  <build_depend>moveit_grasps</build_depend>
+  <build_depend>moveit_grasps_filter</build_depend>
+
+  <build_export_depend>moveit_grasps</build_export_depend>
+  <build_export_depend>moveit_grasps_filter</build_export_depend>
+
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>actionlib</exec_depend>
+  <exec_depend>actionlib_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>shape_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>moveit_core</exec_depend>
+  <exec_depend>moveit_ros_move_group</exec_depend>
+  <exec_depend>moveit_grasps</exec_depend>
+  <exec_depend>moveit_grasps_filter</exec_depend>
+
+  <export>
+    <moveit_ros_move_group plugin="${prefix}/grasp_capability_plugin_description.xml"/>
+  </export>
+
+</package>

--- a/moveit_ros/grasps/package.xml
+++ b/moveit_ros/grasps/package.xml
@@ -19,6 +19,7 @@
   <build_depend>moveit_ros_move_group</build_depend>
   <build_depend>moveit_grasps</build_depend>
   <build_depend>moveit_grasps_filter</build_depend>
+  <build_depend>crop_octomap</build_depend>
 
   <build_export_depend>moveit_grasps</build_export_depend>
   <build_export_depend>moveit_grasps_filter</build_export_depend>

--- a/moveit_ros/grasps/src/grasp_action_capability.cpp
+++ b/moveit_ros/grasps/src/grasp_action_capability.cpp
@@ -1,0 +1,293 @@
+/*
+ * Author: Joshua Supratman
+ * Description: moveit plugin (MoveGroupCapability) for using moveit_grasps
+ */
+
+#include "grasp_action_capability.h"
+#include <moveit/robot_state/robot_state.h>
+#include <moveit/move_group_interface/move_group_interface.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
+#include <moveit/kinematic_constraints/utils.h>
+#include <moveit/planning_interface/planning_interface.h>
+#include <moveit/planning_pipeline/planning_pipeline.h>
+#include <moveit/robot_state/conversions.h>
+#include <moveit/move_group_grasp_capability/capability_names.h>
+
+
+move_group::MoveGroupGraspAction::MoveGroupGraspAction()
+  : MoveGroupCapability("GraspAction"), grasp_state_(IDLE)
+{
+}
+
+
+void move_group::MoveGroupGraspAction::initialize()
+{
+    root_node_handle_.param("planning_group_name", planning_group_name_, std::string("arm"));
+    root_node_handle_.param("ee_group_name", ee_group_name_, std::string("hand"));
+    ROS_INFO_STREAM_NAMED(getName(), "End Effector: " << ee_group_name_);
+    ROS_INFO_STREAM_NAMED(getName(), "Planning Group: " << planning_group_name_);
+
+    loadVisual();
+    setupGraspPipeline();
+
+    grasp_action_server_.reset(new actionlib::SimpleActionServer<moveit_ros_grasp::GraspPlanAction>(
+        root_node_handle_, GRASP_ACTION, boost::bind(&MoveGroupGraspAction::executeCB, this, _1), false));
+    //grasp_action_server_->registerPreemptCallback(boost::bind(&MoveGroupGraspAction::preemptCB, this));
+    grasp_action_server_->start();
+}
+
+void move_group::MoveGroupGraspAction::loadVisual()
+{
+
+    // Load the robot model
+    robot_model_ = context_->planning_scene_monitor_->getRobotModel();
+    arm_jmg_ = robot_model_->getJointModelGroup(planning_group_name_); //TODO: adapt jmg based on called planning group
+
+    // Load the Robot Viz Tools for publishing to Rviz
+    visual_tools_.reset(new moveit_visual_tools::MoveItVisualTools(robot_model_->getModelFrame(),
+                                                                   "/rviz_visual_tools",
+                                                                   context_->planning_scene_monitor_));
+    visual_tools_->loadMarkerPub();
+    //visual_tools_->loadRobotStatePub("/display_robot_state");
+    //visual_tools_->loadTrajectoryPub("/display_planned_path");
+    //visual_tools_->loadSharedRobotState();
+    //visual_tools_->enableBatchPublishing();
+    visual_tools_->deleteAllMarkers();
+    visual_tools_->removeAllCollisionObjects();
+    visual_tools_->trigger();
+}
+
+void move_group::MoveGroupGraspAction::setupGraspPipeline()
+{
+    // ---------------------------------------------------------------------------------------------
+    // Load grasp data specific to our robot
+    grasp_data_.reset(new moveit_grasps::GraspData(root_node_handle_, ee_group_name_, visual_tools_->getRobotModel()));
+
+    // ---------------------------------------------------------------------------------------------
+    // Load grasp generator
+    grasp_generator_.reset(new moveit_grasps::GraspGenerator(visual_tools_));
+
+    // Set the ideal grasp orientation for scoring
+    std::vector<double> ideal_grasp_rpy = { 0.0, 3.141, 0 }; // bin pick rpy
+    grasp_generator_->setIdealTCPGraspPoseRPY(ideal_grasp_rpy);
+
+    // Set custom grasp score weights
+    moveit_grasps::GraspScoreWeights grasp_score_weights;
+    grasp_score_weights.orientation_x_score_weight_ = 2.0;
+    grasp_score_weights.orientation_y_score_weight_ = 2.0;
+    grasp_score_weights.orientation_z_score_weight_ = 2.0;
+    grasp_score_weights.translation_x_score_weight_ = 1.0;
+    grasp_score_weights.translation_y_score_weight_ = 1.0;
+    grasp_score_weights.translation_z_score_weight_ = 1.0;
+    // Finger gripper specific weights.
+    // Note that we do not need to set the suction gripper specific weights for our finger gripper.
+    grasp_score_weights.depth_score_weight_ = 2.0;
+    grasp_score_weights.width_score_weight_ = 2.0;
+    grasp_generator_->setGraspScoreWeights(grasp_score_weights);
+
+    // ---------------------------------------------------------------------------------------------
+    // Load grasp filter
+    grasp_filter_.reset(new moveit_grasps::GraspFilter(visual_tools_->getSharedRobotState(), visual_tools_));
+
+    // ---------------------------------------------------------------------------------------------
+    // Load grasp planner for approach, lift and retreat planning
+    grasp_planner_.reset(new moveit_grasps::GraspPlanner(visual_tools_));
+}
+
+
+
+void move_group::MoveGroupGraspAction::executeCB(const moveit_ros_grasp::GraspPlanGoalConstPtr &goal)
+{
+    //setGraspState(PLANNING);
+
+    // Delete previous markers
+    visual_tools_->deleteAllMarkers();
+    visual_tools_->removeAllCollisionObjects();
+    visual_tools_->trigger();
+
+    // Plan grasps
+    geometry_msgs::Pose object_pose = goal->object_pose;
+    shape_msgs::SolidPrimitive object_shape = goal->object_shape;
+    EigenSTL::vector_Isometry3d waypoints;
+    bool success = generateGraspPlan(waypoints, object_pose, object_shape);
+
+    if(success){
+      feedback_.pregrasp_pose = normalizeQuaternion(visual_tools_->convertPose(waypoints[0]));
+      feedback_.approach_pose = normalizeQuaternion(visual_tools_->convertPose(waypoints[1]));
+      feedback_.lift_pose     = normalizeQuaternion(visual_tools_->convertPose(waypoints[2]));
+      feedback_.retreat_pose  = normalizeQuaternion(visual_tools_->convertPose(waypoints[3]));
+      grasp_action_server_->publishFeedback(feedback_);
+      ros::Duration(0.1).sleep();
+    }
+
+    result_.success = success;
+    grasp_action_server_->setSucceeded(result_);
+}
+
+geometry_msgs::Pose move_group::MoveGroupGraspAction::normalizeQuaternion(geometry_msgs::Pose object_pose)
+  {
+    tf2::Quaternion quat;
+    geometry_msgs::Quaternion orient = object_pose.orientation;
+
+    tf2::fromMsg(orient, quat);
+    quat = quat.normalized();
+    orient = tf2::toMsg(quat);
+    object_pose.orientation = orient;
+
+    return object_pose;
+}
+
+bool move_group::MoveGroupGraspAction::generateGraspPlan(EigenSTL::vector_Isometry3d &grasp_waypoints, 
+                                                         const geometry_msgs::Pose object_pose, 
+                                                         const shape_msgs::SolidPrimitive object_shape)
+{
+    // -----------------------------------
+    // Define object to grasp
+    double object_x_depth  = object_shape.dimensions[0];
+    double object_y_width  = object_shape.dimensions[1];
+    double object_z_height = object_shape.dimensions[2];
+    std::string object_name = "object_link";
+
+    //visualize object
+    visual_tools_->publishCollisionCuboid(object_pose, object_x_depth, object_y_width, object_z_height, object_name, rviz_visual_tools::RED);
+    visual_tools_->publishAxis(object_pose, rviz_visual_tools::MEDIUM);
+    visual_tools_->trigger();
+   
+
+    setACMFingerEntry(object_name, true);
+
+    // -----------------------------------
+    // Generate grasp candidates
+    std::vector<moveit_grasps::GraspCandidatePtr> grasp_candidates;
+
+    // Configure the desired types of grasps
+    moveit_grasps::GraspCandidateConfig grasp_generator_config = moveit_grasps::GraspCandidateConfig();
+    grasp_generator_config.disableAll();
+    grasp_generator_config.enable_face_grasps_ = true;
+    grasp_generator_config.generate_y_axis_grasps_ = true;
+    grasp_generator_config.generate_x_axis_grasps_ = true;
+    grasp_generator_config.generate_z_axis_grasps_ = true;
+
+    if (!grasp_generator_->generateGrasps(visual_tools_->convertPose(object_pose), object_x_depth, object_y_width,
+                                          object_z_height, grasp_data_, grasp_candidates, grasp_generator_config))
+    {
+      ROS_ERROR_NAMED(getName(), "Grasp generator failed to generate any valid grasps");
+      return false;
+    }
+
+    // --------------------------------------------
+    // Generating a seed state for filtering grasps
+    robot_state::RobotStatePtr seed_state(new robot_state::RobotState(*visual_tools_->getSharedRobotState()));
+    Eigen::Isometry3d eef_mount_grasp_pose =
+        visual_tools_->convertPose(object_pose) * grasp_data_->tcp_to_eef_mount_.inverse();
+    if (!getIKSolution(arm_jmg_, eef_mount_grasp_pose, *seed_state, grasp_data_->parent_link_->getName()))
+    {
+      ROS_WARN_NAMED(getName(), "The ideal seed state is not reachable. Using start state as seed.");
+    }
+
+    // --------------------------------------------
+    // Filtering grasps
+    // Note: This step also solves for the grasp and pre-grasp states and stores them in grasp candidates)
+    bool filter_pregrasps = true;
+    if (!grasp_filter_->filterGrasps(grasp_candidates, context_->planning_scene_monitor_, arm_jmg_, seed_state, filter_pregrasps))
+    {
+      ROS_ERROR_NAMED(getName(), "Filter grasps failed");
+      return false;
+    }
+    if (!grasp_filter_->removeInvalidAndFilter(grasp_candidates))
+    {
+      ROS_WARN_NAMED(getName(), "Grasp filtering removed all grasps");
+      return false;
+    }
+    ROS_INFO_STREAM_NAMED(getName(), "" << grasp_candidates.size() << " remain after filtering");
+
+    // Plan free-space approach, cartesian approach, lift and retreat trajectories
+    moveit_grasps::GraspCandidatePtr selected_grasp_candidate;
+    if (!planFullGrasp(grasp_candidates, selected_grasp_candidate))
+    {
+      ROS_ERROR_NAMED(getName(), "Failed to plan grasp motions");
+      return false;
+    }
+
+    // --------------------------------------------
+    // Returning grasp waypoints
+    EigenSTL::vector_Isometry3d waypoints;
+    moveit_grasps::GraspGenerator::getGraspWaypoints(selected_grasp_candidate, waypoints);
+    grasp_waypoints = waypoints;
+
+    // Visualize waypoints
+    visual_tools_->publishAxisLabeled(waypoints[0], "pregrasp");
+    visual_tools_->publishAxisLabeled(waypoints[1], "grasp");
+    visual_tools_->publishAxisLabeled(waypoints[2], "lifted");
+    visual_tools_->publishAxisLabeled(waypoints[3], "retreat");
+    visual_tools_->trigger();
+
+    //setACMFingerEntry(object_name, false);
+
+    return true;
+}
+
+bool move_group::MoveGroupGraspAction::getIKSolution(const moveit::core::JointModelGroup* arm_jmg, 
+                                                     const Eigen::Isometry3d& target_pose,
+                                                     robot_state::RobotState& solution, 
+                                                     const std::string& link_name)
+{
+    boost::scoped_ptr<planning_scene_monitor::LockedPlanningSceneRW> ls(
+        new planning_scene_monitor::LockedPlanningSceneRW(context_->planning_scene_monitor_));
+
+    moveit::core::GroupStateValidityCallbackFn constraint_fn = boost::bind(
+        &isStateValid, static_cast<const planning_scene::PlanningSceneConstPtr&>(*ls).get(), visual_tools_, _1, _2, _3);
+
+    // seed IK call with current state
+    solution = (*ls)->getCurrentState();
+
+    // Solve IK problem for arm
+    // disable explicit restarts to guarantee close solution if one exists
+    const double timeout = 0.1;
+    return solution.setFromIK(arm_jmg, target_pose, link_name, timeout, constraint_fn);
+}
+
+
+bool move_group::MoveGroupGraspAction::planFullGrasp(std::vector<moveit_grasps::GraspCandidatePtr> grasp_candidates,
+                                                     moveit_grasps::GraspCandidatePtr& valid_grasp_candidate)
+{
+    moveit::core::RobotStatePtr current_state;
+    {
+      boost::scoped_ptr<planning_scene_monitor::LockedPlanningSceneRW> ls(
+          new planning_scene_monitor::LockedPlanningSceneRW(context_->planning_scene_monitor_));
+      current_state.reset(new moveit::core::RobotState((*ls)->getCurrentState()));
+    }
+
+    bool success = false;
+    for (; !grasp_candidates.empty(); grasp_candidates.erase(grasp_candidates.begin()))
+    {
+      valid_grasp_candidate = grasp_candidates.front();
+      valid_grasp_candidate->getPreGraspState(current_state);
+      if (!grasp_planner_->planApproachLiftRetreat(valid_grasp_candidate, current_state, context_->planning_scene_monitor_, false))
+      {
+        ROS_INFO_NAMED(getName(), "failed to plan approach lift retreat");
+        continue;
+      }
+        
+      success = true;
+      break;
+    }
+    return success;
+}
+
+void move_group::MoveGroupGraspAction::setACMFingerEntry(const std::string& object_name, bool allowed)
+{
+    planning_scene_monitor::LockedPlanningSceneRW scene(context_->planning_scene_monitor_);  // Lock planning scene
+
+    // Get links of end effector
+    const std::vector<std::string>& ee_links = grasp_data_->ee_jmg_->getLinkModelNames();
+
+    // Set collision checking between fingers and object
+    for (std::size_t i = 0; i < ee_links.size(); ++i)
+    {
+      scene->getAllowedCollisionMatrixNonConst().setEntry(object_name, ee_links[i], allowed);
+    }
+}
+
+#include <class_loader/class_loader.hpp>
+CLASS_LOADER_REGISTER_CLASS(move_group::MoveGroupGraspAction, move_group::MoveGroupCapability)

--- a/moveit_ros/grasps/src/grasp_action_capability.h
+++ b/moveit_ros/grasps/src/grasp_action_capability.h
@@ -26,17 +26,7 @@
 #include <moveit_grasps/grasp_planner.h>
 
 #include <moveit_ros_grasp/GraspPlanAction.h>
-
-// MoveIt
-/*
-#include <moveit/robot_state/robot_state.h>
-#include <moveit/move_group_interface/move_group_interface.h>
-#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
-#include <moveit/kinematic_constraints/utils.h>
-#include <moveit/planning_interface/planning_interface.h>
-#include <moveit/planning_pipeline/planning_pipeline.h>
-#include <moveit/robot_state/conversions.h>
-*/
+#include "crop_octomap/CropObject.h"
 
 namespace move_group
 {
@@ -93,6 +83,7 @@ private:
 
   MoveGroupState grasp_state_;
   //void setGraspState(MoveGroupState state);
+  ros::Publisher client_;
 
 };
 }

--- a/moveit_ros/grasps/src/grasp_action_capability.h
+++ b/moveit_ros/grasps/src/grasp_action_capability.h
@@ -1,0 +1,101 @@
+/*
+ * Author: Joshua Supratman
+ * Description: moveit plugin (MoveGroupCapability) for using moveit_grasps
+ */
+
+#ifndef MOVEIT_MOVE_GROUP_GRASP_ACTION_CAPABILITY_
+#define MOVEIT_MOVE_GROUP_GRASP_ACTION_CAPABILITY_
+
+// plugin library (includes moveit related library)
+#include <moveit/move_group/move_group_capability.h>
+
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <shape_msgs/SolidPrimitive.h>
+#include <tf/transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+#include <moveit_visual_tools/moveit_visual_tools.h>
+#include <actionlib/server/simple_action_server.h>
+#include <rosparam_shortcuts/rosparam_shortcuts.h>
+#include <moveit_grasps/grasp_generator.h>
+#include <moveit_grasps/grasp_filter.h>
+#include <moveit_grasps/grasp_data.h>
+#include <moveit_grasps/grasp_planner.h>
+
+#include <moveit_ros_grasp/GraspPlanAction.h>
+
+// MoveIt
+/*
+#include <moveit/robot_state/robot_state.h>
+#include <moveit/move_group_interface/move_group_interface.h>
+#include <moveit/planning_scene_monitor/planning_scene_monitor.h>
+#include <moveit/kinematic_constraints/utils.h>
+#include <moveit/planning_interface/planning_interface.h>
+#include <moveit/planning_pipeline/planning_pipeline.h>
+#include <moveit/robot_state/conversions.h>
+*/
+
+namespace move_group
+{
+namespace{
+  bool isStateValid(const planning_scene::PlanningScene* planning_scene, 
+                    moveit_visual_tools::MoveItVisualToolsPtr visual_tools, 
+                    robot_state::RobotState* robot_state, 
+                    const robot_model::JointModelGroup* group, 
+                    const double* ik_solution)
+  {
+    robot_state->setJointGroupPositions(group, ik_solution);
+    robot_state->update();
+    return !planning_scene->isStateColliding(*robot_state, group->getName());
+  }
+}
+
+class MoveGroupGraspAction: public MoveGroupCapability
+{
+public:
+  MoveGroupGraspAction();
+  void initialize() override;
+
+private:
+  void loadVisual();
+  void setupGraspPipeline();
+  void executeCB(const moveit_ros_grasp::GraspPlanGoalConstPtr &goal);
+  geometry_msgs::Pose normalizeQuaternion(geometry_msgs::Pose object_pose);
+  bool generateGraspPlan(EigenSTL::vector_Isometry3d &grasp_waypoints, 
+                         const geometry_msgs::Pose object_pose, 
+                         const shape_msgs::SolidPrimitive object_shape);
+  bool getIKSolution(const moveit::core::JointModelGroup* arm_jmg, 
+                     const Eigen::Isometry3d& target_pose, 
+                     robot_state::RobotState& solution, 
+                     const std::string& link_name);
+  bool planFullGrasp(std::vector<moveit_grasps::GraspCandidatePtr> grasp_candidates, 
+                     moveit_grasps::GraspCandidatePtr& valid_grasp_candidate);
+  void setACMFingerEntry(const std::string& object_name, bool allowed);
+
+  std::unique_ptr<actionlib::SimpleActionServer<moveit_ros_grasp::GraspPlanAction>  > grasp_action_server_;
+  moveit_ros_grasp::GraspPlanFeedback feedback_;
+  moveit_ros_grasp::GraspPlanResult result_;
+
+  moveit_visual_tools::MoveItVisualToolsPtr visual_tools_;
+
+  moveit_grasps::GraspGeneratorPtr grasp_generator_;
+  moveit_grasps::GraspDataPtr grasp_data_;
+  moveit_grasps::GraspPlannerPtr grasp_planner_;
+  moveit_grasps::GraspFilterPtr grasp_filter_;
+
+  const robot_model::JointModelGroup* arm_jmg_;
+  robot_model::RobotModelConstPtr robot_model_;
+  std::string ee_group_name_;
+  std::string planning_group_name_;
+
+  MoveGroupState grasp_state_;
+  //void setGraspState(MoveGroupState state);
+
+};
+}
+
+#endif
+

--- a/moveit_ros/moveit_ros/package.xml
+++ b/moveit_ros/moveit_ros/package.xml
@@ -27,6 +27,7 @@
   <exec_depend>moveit_ros_planning_interface</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
   <exec_depend>moveit_ros_manipulation</exec_depend>
+  <exec_depend>moveit_ros_grasp</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
 
   <export>


### PR DESCRIPTION
## Summary
MoveIt! [plugin](https://moveit.ros.org/documentation/plugins/) for planning grasp using [MoveIt! Grasp](https://ros-planning.github.io/moveit_tutorials/doc/moveit_grasps/moveit_grasps_tutorial.html).

## Detail
* move_base.launchを立ち上げることでgrasp action serverも立ち上がる(ROSトピックベース)
* grasp action serverに物体の姿勢と位置を渡すことで物体のピックプランニングを行う
  * pre-grasp, approach, lift, retreatの座標を戻す
* MoveItのplanning sceneを共有しているため障害物を考慮するプランニングを行える

## Test
- [x] シミュレータ 
- [x] cuboidくん

## Installation
端末に以下のコマンドを入力
```
$ wstool init src
$ wstool merge -t src https://raw.githubusercontent.com/ros-planning/moveit/master/moveit.rosinstall
$ wstool update -t src
$ rosdep install -y --from-paths src --ignore-src --rosdistro ${ROS_DISTRO}
$ catkin config --extend /opt/ros/${ROS_DISTRO} --cmake-args -DCMAKE_BUILD_TYPE=Release 
```