### PR TITLE
service to enable/disable octomap monitor

### DIFF
--- a/moveit_ros/move_group/CMakeLists.txt
+++ b/moveit_ros/move_group/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(moveit_move_group_default_capabilities
   src/default_capabilities/get_planning_scene_service_capability.cpp
   src/default_capabilities/apply_planning_scene_service_capability.cpp
   src/default_capabilities/clear_octomap_service_capability.cpp
+  src/default_capabilities/set_octomap_monitor_service_capability.cpp
   )
 set_target_properties(moveit_move_group_default_capabilities PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
 add_dependencies(moveit_move_group_default_capabilities ${catkin_EXPORTED_TARGETS})

--- a/moveit_ros/move_group/default_capabilities_plugin_description.xml
+++ b/moveit_ros/move_group/default_capabilities_plugin_description.xml
@@ -66,4 +66,10 @@
     </description>
   </class>
 
+  <class name="move_group/SetOctomapMonitorService" type="move_group::SetOctomapMonitorService" base_class_type="move_group::MoveGroupCapability">
+    <description>
+      Provide a ROS service that allows for setting the octomap monitor
+    </description>
+  </class>
+
 </library>

--- a/moveit_ros/move_group/include/moveit/move_group/capability_names.h
+++ b/moveit_ros/move_group/include/moveit/move_group/capability_names.h
@@ -63,6 +63,8 @@ static const std::string APPLY_PLANNING_SCENE_SERVICE_NAME =
     "apply_planning_scene";  // name of the service that applies a given planning scene
 static const std::string CLEAR_OCTOMAP_SERVICE_NAME =
     "clear_octomap";  // name of the service that can be used to clear the octomap
+static const std::string SET_OCTOMAP_MONITOR_SERVICE_NAME =
+    "set_octomap_monitor";  // name of the service that can be used to set the octomap monitor
 }
 
 #endif

--- a/moveit_ros/move_group/src/default_capabilities/set_octomap_monitor_service_capability.cpp
+++ b/moveit_ros/move_group/src/default_capabilities/set_octomap_monitor_service_capability.cpp
@@ -1,0 +1,43 @@
+/*
+ * Author: Joshua Supratman
+ * Description: service to enable/disable octomap monitor
+ */
+#include "set_octomap_monitor_service_capability.h"
+#include <moveit/move_group/capability_names.h>
+
+move_group::SetOctomapMonitorService::SetOctomapMonitorService() : MoveGroupCapability("SetOctomapMonitorService")
+{
+}
+
+void move_group::SetOctomapMonitorService::initialize()
+{
+  service_ = root_node_handle_.advertiseService(SET_OCTOMAP_MONITOR_SERVICE_NAME, &SetOctomapMonitorService::setOctomapMonitor, this);
+}
+
+bool move_group::SetOctomapMonitorService::setOctomapMonitor(std_srvs::SetBool::Request& req, std_srvs::SetBool::Response& res)
+{
+  if (!context_->planning_scene_monitor_)
+  {
+    ROS_ERROR("Cannot set octomap monitor since planning_scene_monitor_ does not exist.");
+    res.success = false;
+    return true;
+  }
+  if(req.data)
+  {
+    context_->planning_scene_monitor_->startOctomapMonitor();
+    //context_->planning_scene_monitor_->clearOctomap();
+    ROS_INFO("start octomap update");
+  }
+  else
+  {
+    context_->planning_scene_monitor_->stopOctomapMonitor();
+    //context_->planning_scene_monitor_->clearOctomap();
+    ROS_INFO("stop octomap update");
+  }
+  res.success = true;
+
+  return true;
+}
+
+#include <class_loader/class_loader.hpp>
+CLASS_LOADER_REGISTER_CLASS(move_group::SetOctomapMonitorService, move_group::MoveGroupCapability)

--- a/moveit_ros/move_group/src/default_capabilities/set_octomap_monitor_service_capability.h
+++ b/moveit_ros/move_group/src/default_capabilities/set_octomap_monitor_service_capability.h
@@ -1,0 +1,27 @@
+/*
+ * Author: Joshua Supratman
+ * Description: service to enable/disable octomap monitor
+ */
+#ifndef MOVEIT_MOVE_GROUP_SET_OCTOMAP_MONITOR_SERVICE_CAPABILITY_
+#define MOVEIT_MOVE_GROUP_SET_OCTOMAP_MONITOR_SERVICE_CAPABILITY_
+
+#include <moveit/move_group/move_group_capability.h>
+#include <std_srvs/SetBool.h>
+
+namespace move_group
+{
+class SetOctomapMonitorService : public MoveGroupCapability
+{
+public:
+  SetOctomapMonitorService();
+
+  void initialize() override;
+
+private:
+  bool setOctomapMonitor(std_srvs::SetBool::Request& req, std_srvs::SetBool::Response& res);
+
+  ros::ServiceServer service_;
+};
+}
+
+#endif  // MOVEIT_MOVE_GROUP_SET_OCTOMAP_MONITOR_SERVICE_CAPABILITY_

--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -63,6 +63,7 @@ static const char* DEFAULT_CAPABILITIES[] = {
    "move_group/MoveGroupGetPlanningSceneService",
    "move_group/ApplyPlanningSceneService",
    "move_group/ClearOctomapService",
+   "move_group/SetOctomapMonitorService",
 };
 // clang-format on
 

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_monitor.h
@@ -70,6 +70,8 @@ public:
 
   void stopMonitor();
 
+  void enableMonitor(bool flag, bool clear_octomap=false);
+
   /** @brief Get a pointer to the underlying octree for this monitor. Lock the tree before reading or writing using this
    *  pointer. The value of this pointer stays the same throughout the existance of the monitor instance. */
   const OccMapTreePtr& getOcTreePtr()

--- a/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
+++ b/moveit_ros/occupancy_map_monitor/include/moveit/occupancy_map_monitor/occupancy_map_updater.h
@@ -79,6 +79,8 @@ public:
 
   virtual void stop() = 0;
 
+  virtual void enable(bool flag, bool clear_octomap) = 0;
+
   virtual ShapeHandle excludeShape(const shapes::ShapeConstPtr& shape) = 0;
 
   virtual void forgetShape(ShapeHandle handle) = 0;

--- a/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
+++ b/moveit_ros/occupancy_map_monitor/src/occupancy_map_monitor.cpp
@@ -353,6 +353,12 @@ void OccupancyMapMonitor::stopMonitor()
     map_updaters_[i]->stop();
 }
 
+void OccupancyMapMonitor::enableMonitor(bool flag, bool clear_octomap)
+{
+  for (std::size_t i = 0; i < map_updaters_.size(); ++i)
+    map_updaters_[i]->enable(flag, clear_octomap);
+}
+
 OccupancyMapMonitor::~OccupancyMapMonitor()
 {
   stopMonitor();

--- a/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
+++ b/moveit_ros/perception/depth_image_octomap_updater/include/moveit/depth_image_octomap_updater/depth_image_octomap_updater.h
@@ -58,6 +58,7 @@ public:
   bool initialize() override;
   void start() override;
   void stop() override;
+  void enable(bool flag, bool clear_octomap) override;
   ShapeHandle excludeShape(const shapes::ShapeConstPtr& shape) override;
   void forgetShape(ShapeHandle handle) override;
 
@@ -79,6 +80,9 @@ private:
   image_transport::CameraPublisher pub_filtered_label_image_;
 
   ros::Time last_update_time_;
+
+  bool enable_update_;
+  bool clear_octomap_;
 
   std::string filtered_cloud_topic_;
   std::string sensor_type_;

--- a/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
+++ b/moveit_ros/perception/pointcloud_octomap_updater/include/moveit/pointcloud_octomap_updater/pointcloud_octomap_updater.h
@@ -60,6 +60,7 @@ public:
   bool initialize() override;
   void start() override;
   void stop() override;
+  void enable(bool flag, bool clear_octomap) override;
   ShapeHandle excludeShape(const shapes::ShapeConstPtr& shape) override;
   void forgetShape(ShapeHandle handle) override;
 
@@ -79,6 +80,9 @@ private:
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   ros::Time last_update_time_;
+
+  bool enable_update_;
+  bool clear_octomap_;
 
   /* params */
   std::string point_cloud_topic_;

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -367,6 +367,12 @@ public:
   /** @brief Stop the world geometry monitor */
   void stopWorldGeometryMonitor();
 
+  /** @brief Start the octomap monitor */
+  void startOctomapMonitor();
+
+  /** @brief Stop the octomap monitor */
+  void stopOctomapMonitor();
+
   /** @brief Add a function to be called when an update to the scene is received */
   void addUpdateCallback(const boost::function<void(SceneUpdateType)>& fn);
 
@@ -469,6 +475,8 @@ protected:
   boost::shared_mutex scene_update_mutex_;         /// mutex for stored scene
   ros::Time last_update_time_;                     /// Last time the state was updated
   ros::Time last_robot_motion_time_;               /// Last time the robot has moved
+
+  bool enable_update_;
 
   ros::NodeHandle nh_;
   ros::NodeHandle root_nh_;

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -136,7 +136,7 @@ PlanningSceneMonitor::PlanningSceneMonitor(const robot_model_loader::RobotModelL
 PlanningSceneMonitor::PlanningSceneMonitor(const planning_scene::PlanningScenePtr& scene,
                                            const robot_model_loader::RobotModelLoaderPtr& rm_loader,
                                            const std::shared_ptr<tf2_ros::Buffer>& tf_buffer, const std::string& name)
-  : monitor_name_(name), nh_("~"), tf_buffer_(tf_buffer), rm_loader_(rm_loader)
+  : monitor_name_(name), nh_("~"), tf_buffer_(tf_buffer), rm_loader_(rm_loader), enable_update_(true)
 {
   root_nh_.setCallbackQueue(&queue_);
   nh_.setCallbackQueue(&queue_);
@@ -537,6 +537,8 @@ void PlanningSceneMonitor::newPlanningSceneCallback(const moveit_msgs::PlanningS
 
 void PlanningSceneMonitor::clearOctomap()
 {
+  if(!enable_update_)
+    octomap_monitor_->enableMonitor(false, true);
   octomap_monitor_->getOcTreePtr()->lockWrite();
   octomap_monitor_->getOcTreePtr()->clear();
   octomap_monitor_->getOcTreePtr()->unlockWrite();
@@ -1097,6 +1099,21 @@ void PlanningSceneMonitor::stopWorldGeometryMonitor()
   }
   if (octomap_monitor_)
     octomap_monitor_->stopMonitor();
+}
+
+void PlanningSceneMonitor::startOctomapMonitor()
+{
+  if(octomap_monitor_){
+    octomap_monitor_->enableMonitor(true);
+    enable_update_ = true;
+  }
+}
+void PlanningSceneMonitor::stopOctomapMonitor()
+{
+  if(octomap_monitor_){
+    octomap_monitor_->enableMonitor(false);
+    enable_update_ = false;
+  }
 }
 
 void PlanningSceneMonitor::startStateMonitor(const std::string& joint_states_topic,

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1103,14 +1103,14 @@ void PlanningSceneMonitor::stopWorldGeometryMonitor()
 
 void PlanningSceneMonitor::startOctomapMonitor()
 {
-  if(octomap_monitor_){
+  if(octomap_monitor_ && !enable_update_){
     octomap_monitor_->enableMonitor(true);
     enable_update_ = true;
   }
 }
 void PlanningSceneMonitor::stopOctomapMonitor()
 {
-  if(octomap_monitor_){
+  if(octomap_monitor_ && enable_update_){
     octomap_monitor_->enableMonitor(false);
     enable_update_ = false;
   }


### PR DESCRIPTION
### Summary
ROS service that enable/disable octomap monitor. The feature also have a workaround regarding the slow planning time that was address in this [issue](https://github.com/sbgisen/cube_arm/issues/75).

### Detail
- octomapの一時停止を可能にするROSサービスを作成
  - octomapを一時停止: `rosservice call /set_octomap_monitor "data: false" `
  - octomapを再開: `rosservice call /set_octomap_monitor "data: true"`
- [issue](https://github.com/sbgisen/cube_arm/issues/75)の軌道計画が時間かかる問題も考慮
  - octomapの一時停止状態でoctomapクリアサービスを呼びだす時の処理を追加

### Test
- [x] cuboidくん

